### PR TITLE
optional bastion CNAME

### DIFF
--- a/aws-platform-ui-main/eks-vpc.tf
+++ b/aws-platform-ui-main/eks-vpc.tf
@@ -18,7 +18,7 @@ module "eks_vpc" {
 
   aws_account_id = local.account_id
 
-  domain = var.domain
+  human_domain = var.domain
 
   aws_kms_key_arns       = concat([data.aws_kms_key.storage.arn], var.shared_asset_kms_key_arns)
   volumes_aws_kms_key_id = data.aws_kms_key.storage.id
@@ -32,7 +32,6 @@ module "eks_vpc" {
   public_api = true
 
   monitoring                     = var.monitoring
-  use_human_grafana_domain       = var.use_human_grafana_domain
   grafana_saml_admin_role_values = var.grafana_saml_admin_role_values
   grafana_saml_role_assertion    = var.grafana_saml_role_assertion
   grafana_saml_metadata_xml      = var.grafana_saml_metadata_xml

--- a/aws-platform-ui-main/vars.tf
+++ b/aws-platform-ui-main/vars.tf
@@ -78,10 +78,6 @@ variable "grafana_saml_metadata_xml" {
   default = ""
 }
 
-variable "use_human_grafana_domain" {
-  default = false
-}
-
 variable "monitoring" {
   default = true
 }

--- a/eks-vpc/monitoring.tf
+++ b/eks-vpc/monitoring.tf
@@ -429,7 +429,7 @@ module "grafana_frontend_url" {
 
 locals {
   grafana_endpoint     = try(aws_grafana_workspace.grafana[0].endpoint, null)
-  grafana_human_domain = local.monitoring && var.use_human_grafana_domain ? "${module.grafana_frontend_url.prefix}.${var.domain}" : null
+  grafana_human_domain = local.monitoring && var.human_domain != "" ? "${module.grafana_frontend_url.prefix}.${var.human_domain}" : null
   grafana_endpoint_url = try(format("https://%s", local.grafana_endpoint), "")
 }
 
@@ -439,7 +439,7 @@ module "grafana_frontend" {
   source            = "../aws-cf-reverse-proxy"
   luther_env        = var.luther_env
   luther_project    = var.luther_project
-  app_naked_domain  = var.domain
+  app_naked_domain  = var.human_domain
   app_target_domain = local.grafana_human_domain
   origin_url        = local.grafana_endpoint_url
   use_302           = true

--- a/eks-vpc/vars.tf
+++ b/eks-vpc/vars.tf
@@ -25,8 +25,8 @@ variable "worker_instance_type" {
   default = "m6i.large"
 }
 
-variable "domain" {
-  default = "luthersystemsapp.com"
+variable "human_domain" {
+  default = ""
 }
 
 variable "use_bastion" {
@@ -251,10 +251,6 @@ variable "grafana_saml_role_assertion" {
 
 variable "grafana_saml_metadata_xml" {
   default = ""
-}
-
-variable "use_human_grafana_domain" {
-  default = false
 }
 
 variable "preserve_coredns" {


### PR DESCRIPTION
This refactors the CNAME for the bastion to be optional as well, unifying the configuration with the grafana redirect and eliminating the requirement for a DNS zone to be configured.