### PR TITLE
add replication dependency

### DIFF
--- a/aws-s3-bucket-replication/s3_buckets.tf
+++ b/aws-s3-bucket-replication/s3_buckets.tf
@@ -41,6 +41,8 @@ module "aws_s3_bucket" {
   destination_kms_key_arn     = var.aws_kms_key_arn_replica
   replicate_deletes           = var.replicate_deletes
 
+  depends_on = [module.aws_s3_bucket_replica]
+
   providers = {
     aws = aws
   }


### PR DESCRIPTION
This adds a module dependency to guarantee the destination bucket is set up with versioning enabled before creating the replication configuration on the source side.