### PR TITLE
Expose aws_cloudwatch_retention_days in aws-platform-ui-main

### DIFF
--- a/aws-platform-ui-main/eks-vpc.tf
+++ b/aws-platform-ui-main/eks-vpc.tf
@@ -26,6 +26,7 @@ module "eks_vpc" {
 
   monitoring                     = var.monitoring
   logs                           = var.logs
+  aws_cloudwatch_retention_days  = var.aws_cloudwatch_retention_days
   grafana_saml_admin_role_values = var.grafana_saml_admin_role_values
   grafana_saml_role_assertion    = var.grafana_saml_role_assertion
   grafana_saml_metadata_xml      = var.grafana_saml_metadata_xml

--- a/aws-platform-ui-main/vars.tf
+++ b/aws-platform-ui-main/vars.tf
@@ -120,6 +120,11 @@ variable "logs" {
   default = false
 }
 
+variable "aws_cloudwatch_retention_days" {
+  type    = number
+  default = 90
+}
+
 variable "custom_instance_userdata" {
   type    = string
   default = ""


### PR DESCRIPTION
## Summary
- Expose `aws_cloudwatch_retention_days` variable in `aws-platform-ui-main` module
- Passes through to `eks-vpc` submodule's existing `aws_cloudwatch_retention_days` variable
- Default remains 90 days (no change to existing behavior)

This allows consumers (e.g. `platform-test`) to lower CloudWatch log retention to reduce costs. The test environment currently stores 92 GB of logs at 90-day retention; reducing to 14 days will cut storage costs significantly.

## Test plan
- [ ] `terraform validate` passes (CI)
- [ ] Apply in `platform-test` with `aws_cloudwatch_retention_days = 14` — expect in-place update to log group retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)