### PR TITLE
fix: Eliminate perpetual Terraform drift in 4 AWS resources

### DIFF
--- a/aws-platform-ui-bootstrap/admin.tf
+++ b/aws-platform-ui-bootstrap/admin.tf
@@ -1,7 +1,22 @@
+module "luthername_admin_role" {
+  source         = "../luthername"
+  luther_project = var.project
+  aws_region     = local.region
+  luther_env     = var.env
+  org_name       = var.org_name
+  component      = "admin"
+  resource       = "role"
+}
+
 resource "aws_iam_role" "admin" {
   name               = var.admin_role_name
   description        = "Provides administrator level access"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = module.luthername_admin_role.tags
+
+  lifecycle {
+    ignore_changes = [managed_policy_arns]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {

--- a/aws-platform-ui-bootstrap/dns.tf
+++ b/aws-platform-ui-bootstrap/dns.tf
@@ -1,6 +1,18 @@
+module "luthername_dns_zone" {
+  source         = "../luthername"
+  count          = var.create_dns ? 1 : 0
+  luther_project = var.project
+  aws_region     = local.region
+  luther_env     = var.env
+  org_name       = var.org_name
+  component      = "dns"
+  resource       = "zone"
+}
+
 resource "aws_route53_zone" "main" {
-  count = var.create_dns ? 1 : 0 # Only create the resource if var.create_dns is true
+  count = var.create_dns ? 1 : 0
   name  = var.domain
+  tags  = module.luthername_dns_zone[0].tags
 }
 
 output "domain" {

--- a/aws-s3-bucket/s3_buckets.tf
+++ b/aws-s3-bucket/s3_buckets.tf
@@ -30,6 +30,10 @@ resource "aws_s3_bucket" "bucket" {
   )
 
   force_destroy = var.force_destroy
+
+  lifecycle {
+    ignore_changes = [server_side_encryption_configuration, versioning]
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "bucket" {
@@ -44,6 +48,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   bucket = aws_s3_bucket.bucket.id
 
   rule {
+    bucket_key_enabled = false
+
     apply_server_side_encryption_by_default {
       kms_master_key_id = var.aws_kms_key_arn
       sse_algorithm     = "aws:kms"


### PR DESCRIPTION
## Summary

- Add luthername tags to admin IAM role and Route53 zone in `aws-platform-ui-bootstrap` (previously untagged, causing `tags = {}` drift)
- Add `lifecycle { ignore_changes = [managed_policy_arns] }` on admin role to prevent drift from console-attached policies
- Add `lifecycle { ignore_changes = [server_side_encryption_configuration, versioning] }` on S3 bucket to suppress deprecated inline attribute drift
- Set `bucket_key_enabled = false` on S3 encryption config to match AWS default and prevent drift

Closes #58

## Test plan

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes in both `aws-platform-ui-bootstrap/` and `aws-s3-bucket/`
- [ ] `terraform plan` on clean `cloud-provision` stage shows zero drift on these 4 resources
- [ ] New luthername tags appear on admin role and Route53 zone after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)