### PR TITLE
fix: harden bootstrap output guards

### DIFF
--- a/aws-platform-ui-bootstrap/dns.tf
+++ b/aws-platform-ui-bootstrap/dns.tf
@@ -15,16 +15,21 @@ resource "aws_route53_zone" "main" {
   tags  = module.luthername_dns_zone[0].tags
 }
 
+locals {
+  route53_name_servers = try(aws_route53_zone.main[0].name_servers, [])
+  route53_zone_id      = try(aws_route53_zone.main[0].zone_id, "")
+}
+
 output "domain" {
   value = var.create_dns ? var.domain : ""
 }
 
 output "aws_route53_zone_name_servers" {
-  value       = var.create_dns ? aws_route53_zone.main[0].name_servers : []
+  value       = var.create_dns ? local.route53_name_servers : []
   description = "The name servers for the DNS zone. Available only when the zone is created."
 }
 
 output "zone_id" {
-  value       = var.create_dns ? aws_route53_zone.main[0].zone_id : ""
+  value       = var.create_dns ? local.route53_zone_id : ""
   description = "The Zone ID for the DNS zone. Available only when the zone is created."
 }

--- a/aws-platform-ui-bootstrap/state.tf
+++ b/aws-platform-ui-bootstrap/state.tf
@@ -11,6 +11,12 @@ module "luthername_kms_key" {
   resource       = "kms"
 }
 
+locals {
+  tfstate_kms_key_arn = try(aws_kms_key.tfstate[0].arn, "")
+  tfstate_kms_alias   = try(aws_kms_alias.tfstate[0].arn, "")
+  tfstate_bucket_name = try(module.aws_s3_bucket_tfstate[0].bucket, "")
+}
+
 resource "aws_kms_key" "tfstate" {
   count = var.create_state_bucket ? 1 : 0
 
@@ -22,11 +28,16 @@ resource "aws_kms_alias" "tfstate" {
   count = var.create_state_bucket ? 1 : 0
 
   name          = format("alias/%s", var.kms_alias_suffix)
-  target_key_id = aws_kms_key.tfstate.0.arn
+  target_key_id = local.tfstate_kms_key_arn
 }
 
 output "aws_kms_key_id" {
-  value = var.create_state_bucket ? aws_kms_alias.tfstate.0.arn : ""
+  value = var.create_state_bucket ? local.tfstate_kms_alias : ""
+
+  precondition {
+    condition     = !var.create_state_bucket || local.tfstate_kms_alias != ""
+    error_message = "State bucket bootstrap is incomplete: expected the tfstate KMS key/alias to exist when create_state_bucket=true."
+  }
 }
 
 module "aws_s3_bucket_tfstate" {
@@ -37,7 +48,7 @@ module "aws_s3_bucket_tfstate" {
   luther_project  = var.project
   luther_env      = var.env
   component       = "tfstate"
-  aws_kms_key_arn = aws_kms_key.tfstate.0.arn
+  aws_kms_key_arn = local.tfstate_kms_key_arn
 
   force_destroy = true
 
@@ -48,5 +59,10 @@ module "aws_s3_bucket_tfstate" {
 }
 
 output "aws_s3_bucket_tfstate" {
-  value = var.create_state_bucket ? module.aws_s3_bucket_tfstate.0.bucket : ""
+  value = var.create_state_bucket ? local.tfstate_bucket_name : ""
+
+  precondition {
+    condition     = !var.create_state_bucket || local.tfstate_bucket_name != ""
+    error_message = "State bucket bootstrap is incomplete: expected the tfstate S3 bucket to exist when create_state_bucket=true."
+  }
 }

--- a/aws-platform-ui-bootstrap/versions.tf
+++ b/aws-platform-ui-bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- raise `aws-platform-ui-bootstrap` to `required_version = ">= 1.2"` so the module can use output preconditions
- replace direct tuple indexing in DNS/state outputs with guarded locals using `try(...)`
- keep missing tfstate KMS/bucket paths from panicking and fail with descriptive messages instead

## Test plan
- [x] `cd aws-platform-ui-bootstrap && terraform init -backend=false`
- [x] `cd aws-platform-ui-bootstrap && terraform validate`
- [ ] Exercise against a legacy AWS project with missing bootstrap resources

## Related
- Closes #60
- Related: luthersystems/sandbox-infrastructure-template#61

---
Local validation passed. Security review: low-risk Terraform expression changes only; no auth or secret handling changes.
