### PR TITLE
feat: Add EKS 1.34 addon versions and update ALB controller IAM policy

### DIFF
--- a/eks-vpc/aws_lb_controller.tf
+++ b/eks-vpc/aws_lb_controller.tf
@@ -29,8 +29,8 @@ output "aws_lb_controller_service_account_role_arn" {
 }
 
 locals {
-  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.0/docs/install/iam_policy.json
-  # with recommended VPC condition added
+  # https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.17.1/docs/install/iam_policy.json
+  # with recommended VPC condition added to AuthorizeSecurityGroupIngress
   aws_lb_controller_policy = <<POLICY
 {
     "Version": "2012-10-17",
@@ -63,6 +63,9 @@ locals {
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",
@@ -72,7 +75,10 @@ locals {
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
             ],
             "Resource": "*"
         },
@@ -195,7 +201,13 @@ locals {
                 "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
                 "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
                 "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-            ]
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
         },
         {
             "Effect": "Allow",
@@ -220,12 +232,37 @@ locals {
                 "elasticloadbalancing:DeleteLoadBalancer",
                 "elasticloadbalancing:ModifyTargetGroup",
                 "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup"
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
             ],
             "Resource": "*",
             "Condition": {
                 "Null": {
                     "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },
@@ -244,7 +281,8 @@ locals {
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:AddListenerCertificates",
                 "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule"
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
             ],
             "Resource": "*"
         }

--- a/eks-vpc/vars.tf
+++ b/eks-vpc/vars.tf
@@ -176,7 +176,7 @@ variable "managed_nodes" {
   default = true
 }
 
-# See: https://marcincuber.medium.com/amazon-eks-upgrade-journey-from-1-24-to-1-25-e1bcccc2f384
+# See: https://marcincuber.medium.com/amazon-eks-upgrade-journey-from-1-33-to-1-34-of-wind-will-o-waw-899ccca8f07e
 # for versions
 
 # https://github.com/aws/amazon-vpc-cni-k8s/releases
@@ -196,6 +196,7 @@ variable "cni_addon_version" {
     "1.31" = "v1.18.3-eksbuild.3"
     "1.32" = "v1.19.2-eksbuild.1"
     "1.33" = "v1.19.5-eksbuild.3"
+    "1.34" = "v1.20.3-eksbuild.1"
   }
 }
 
@@ -216,6 +217,7 @@ variable "csi_addon_version" {
     "1.31" = "v1.35.0-eksbuild.1"
     "1.32" = "v1.45.0-eksbuild.2"
     "1.33" = "v1.45.0-eksbuild.2"
+    "1.34" = "v1.48.0-eksbuild.2"
   }
 }
 
@@ -235,6 +237,7 @@ variable "kubeproxy_addon_version" {
     "1.31" = "v1.31.0-eksbuild.5"
     "1.32" = "v1.32.0-eksbuild.2"
     "1.33" = "v1.33.0-eksbuild.2"
+    "1.34" = "v1.34.0-eksbuild.4"
   }
 }
 
@@ -254,6 +257,7 @@ variable "coredns_addon_version" {
     "1.31" = "v1.11.3-eksbuild.1"
     "1.32" = "v1.11.4-eksbuild.2"
     "1.33" = "v1.12.1-eksbuild.2"
+    "1.34" = "v1.12.4-eksbuild.1"
   }
 }
 


### PR DESCRIPTION
## Summary

- Add Kubernetes 1.34 compatible addon versions (vpc-cni, kube-proxy, CoreDNS, ebs-csi-driver) sourced from [Marcin Cuber's EKS upgrade blog post](https://marcincuber.medium.com/amazon-eks-upgrade-journey-from-1-33-to-1-34-of-wind-will-o-waw-899ccca8f07e) and his [GitHub repo](https://github.com/marcincuber/eks)
- Update AWS Load Balancer Controller IAM policy from v2.4.0 to v2.17.1, adding 10 new required IAM actions ahead of the controller version upgrade tracked in luthersystems/mars#114
- Update blog post reference URL in vars.tf comment

## Addon Versions for 1.34

| Addon | Version |
|-------|---------|
| vpc-cni | `v1.20.3-eksbuild.1` |
| kube-proxy | `v1.34.0-eksbuild.4` |
| CoreDNS | `v1.12.4-eksbuild.1` |
| ebs-csi-driver | `v1.48.0-eksbuild.2` |

## ALB Controller IAM Policy Changes

New actions added to match the [v2.17.1 upstream policy](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.17.1/docs/install/iam_policy.json):

- `ec2:GetSecurityGroupsForVpc`, `ec2:DescribeIpamPools`, `ec2:DescribeRouteTables`
- `elasticloadbalancing:DescribeTrustStores`, `DescribeListenerAttributes`, `DescribeCapacityReservation`
- `elasticloadbalancing:ModifyListenerAttributes`, `ModifyCapacityReservation`, `ModifyIpPools`
- `elasticloadbalancing:SetRulePriorities`
- New `AddTags` statement with `CreateAction` condition (tighter security)
- Tightened existing `AddTags/RemoveTags` on LB/TG with proper tag condition

Custom VPC condition on `AuthorizeSecurityGroupIngress` is preserved.

## Notes

- The actual ALB controller Helm chart + image tag upgrade is a separate change in the mars repo: luthersystems/mars#114
- **Deploy order**: apply this IAM policy update first, then upgrade the controller version in mars
- No breaking changes in K8s 1.34 itself (no API deprecations or removals)
- EBS CSI v1.48.0 is safe since we don't use VolumeAttributesClass (verified on plt-test cluster)

## Test plan

- [ ] `terraform plan` on test environment shows only IAM policy + addon version changes
- [ ] Apply IAM policy update to test cluster
- [ ] Upgrade EKS control plane to 1.34 on test cluster
- [ ] Verify all addons reconcile to new versions
- [ ] Verify ALB/ingress resources remain healthy