### PR TITLE
aws-cf-reverse-proxy: add per-behavior gRPC support via grpc_routes

### DIFF
--- a/aws-cf-reverse-proxy/main.tf
+++ b/aws-cf-reverse-proxy/main.tf
@@ -22,6 +22,26 @@ locals {
     }
   }
 
+  grpc_origin_configs = {
+    for path, url in var.grpc_routes :
+    path => {
+      origin_id     = "origin-grpc-${replace(trim(path, "/*"), "[^a-zA-Z0-9]", "-")}"
+      origin_domain = regex("^https?://([^/]+)", url)[0]
+      origin_path   = try(regex("^https?://[^/]+(/.*)", url)[0], null)
+    }
+  }
+
+  # Combined origin set used by the distribution. gRPC entries get distinct
+  # origin_ids ("origin-grpc-...") so they never collide with HTTP origins,
+  # even when the underlying origin URL is the same ALB.
+  all_origin_configs = merge(
+    local.origin_configs,
+    {
+      for path, cfg in local.grpc_origin_configs :
+      "__grpc__${path}" => cfg
+    },
+  )
+
   random_id = var.random_identifier == "" ? random_string.id[0].result : var.random_identifier
 
   app_route53_zone_name = var.app_route53_zone_name != "" ? var.app_route53_zone_name : var.app_naked_domain
@@ -96,12 +116,14 @@ resource "aws_route53_record" "site" {
 }
 
 resource "aws_cloudfront_distribution" "site" {
-  enabled      = true
-  price_class  = "PriceClass_200"
-  http_version = "http2"
+  enabled     = true
+  price_class = "PriceClass_200"
+  # gRPC requires HTTP/2 end-to-end. Promote http_version only when there is
+  # at least one gRPC route, so existing distributions stay byte-identical.
+  http_version = length(var.grpc_routes) > 0 ? "http2and3" : "http2"
 
   dynamic "origin" {
-    for_each = local.origin_configs
+    for_each = local.all_origin_configs
     content {
       origin_id   = origin.value.origin_id
       domain_name = origin.value.origin_domain
@@ -141,6 +163,28 @@ resource "aws_cloudfront_distribution" "site" {
       cache_policy_id = aws_cloudfront_cache_policy.respect_origin_headers.id
 
       response_headers_policy_id = local.use_cors ? aws_cloudfront_response_headers_policy.allow_specified_origins[0].id : null
+    }
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = local.grpc_origin_configs
+
+    content {
+      path_pattern           = ordered_cache_behavior.key
+      target_origin_id       = ordered_cache_behavior.value.origin_id
+      viewer_protocol_policy = "redirect-to-https"
+
+      # CloudFront gRPC behaviors require the full method set.
+      allowed_methods = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods  = ["GET", "HEAD"]
+
+      cache_policy_id = aws_cloudfront_cache_policy.respect_origin_headers.id
+
+      response_headers_policy_id = local.use_cors ? aws_cloudfront_response_headers_policy.allow_specified_origins[0].id : null
+
+      grpc_config {
+        enabled = true
+      }
     }
   }
 

--- a/aws-cf-reverse-proxy/vars.tf
+++ b/aws-cf-reverse-proxy/vars.tf
@@ -60,6 +60,12 @@ variable "origin_routes" {
   default     = {}
 }
 
+variable "grpc_routes" {
+  type        = map(string)
+  default     = {}
+  description = "Path-pattern => origin URL map for gRPC cache behaviors. Each entry registers an ordered_cache_behavior with grpc_config { enabled = true }. When non-empty, distribution http_version is automatically promoted to http2and3 (gRPC requires HTTP/2)."
+}
+
 variable "use_cors" {
   type    = bool
   default = false


### PR DESCRIPTION
Closes #63
Companion follow-up: luthersystems/ui-infrastructure#241

## Summary

Adds opt-in gRPC support to `aws-cf-reverse-proxy` so consumers can register CloudFront cache behaviors that speak gRPC to an EKS ALB origin. Existing distributions with no `grpc_routes` set produce a zero-diff plan.

## Changes

- **`vars.tf`**: new `grpc_routes = map(string)` (default `{}`).
- **`main.tf`**:
  - New `local.grpc_origin_configs` derives an origin per gRPC route with a distinct `origin-grpc-...` id. A combined `local.all_origin_configs` feeds the `dynamic "origin"` block; when `grpc_routes = {}` it is identical to `local.origin_configs`, preserving the exact origin set.
  - `http_version` flips to `http2and3` only when `length(grpc_routes) > 0`, otherwise stays `http2`.
  - New `dynamic "ordered_cache_behavior"` iterates `grpc_origin_configs` and emits `grpc_config { enabled = true }` plus the full method set CloudFront requires for gRPC behaviors. Reuses the existing cache and response-headers policies.

## Design notes

- gRPC origins use `origin-grpc-<sanitized-path>` ids so they never collide with HTTP origins, even when the underlying origin URL is the same ALB. No de-duplication: CloudFront accepts multiple origins pointing at the same domain under distinct ids, and this keeps the locals graph dead simple. If a future consumer wants a shared origin between HTTP and gRPC behaviors, that's an additive change.
- `compress` is intentionally omitted on gRPC behaviors (provider default `false`); gRPC handles compression at the protocol layer.
- The new internal map key prefix `__grpc__<path>` exists only for `for_each` iteration; it never appears in any rendered AWS resource (the dynamic block emits `origin.value.origin_id`, not the key).

## Verification

- [x] `terraform fmt -recursive aws-cf-reverse-proxy/` clean.
- [x] `terraform validate` against `aws-cf-reverse-proxy/tests/test1/` (AWS provider 6.44.0): clean both with the default test (`grpc_routes` unset) and with a sample entry `{"/a2a.v1.A2AService/*" = "https://eks-alb.example.com"}`.
- [x] Back-compat for `grpc_routes = {}` is **structurally guaranteed**:
  - `local.grpc_origin_configs = {}`
  - `local.all_origin_configs = merge(origin_configs, {}) == origin_configs`
  - new `dynamic "ordered_cache_behavior"` iterates over `{}` -> zero blocks
  - `http_version = length({}) > 0 ? "http2and3" : "http2"` -> `"http2"`
- [x] With one `grpc_routes` entry, plan would show: 1 added origin (`origin-grpc-...`), 1 added `ordered_cache_behavior` with `grpc_config { enabled = true }`, and `http_version` flipping `http2 -> http2and3`. No other in-place changes.

## Follow-up

- Tag a new release after merge so `ui-infrastructure` can bump `?ref=` and add a `grpc_routes` entry. The issue suggests `v56.0.0`; current latest tag is `v55.15.2`. **Not cutting the tag here** — leaving that to a maintainer.
- The `ui-infrastructure` consumer side is tracked in luthersystems/ui-infrastructure#241; chart side in luthersystems/mars#131.