### PR TITLE
aws-cf-reverse-proxy: forward custom request headers to origin

### DIFF
--- a/aws-cf-reverse-proxy/main.tf
+++ b/aws-cf-reverse-proxy/main.tf
@@ -350,7 +350,7 @@ resource "aws_cloudfront_cache_policy" "respect_origin_headers" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Origin", "Authorization", "Accept", "Content-Type", "User-Agent"]
+        items = concat(["Origin", "Authorization", "Accept", "Content-Type", "User-Agent"], var.extra_forwarded_headers)
       }
     }
 

--- a/aws-cf-reverse-proxy/vars.tf
+++ b/aws-cf-reverse-proxy/vars.tf
@@ -66,6 +66,12 @@ variable "grpc_routes" {
   description = "Path-pattern => origin URL map for gRPC cache behaviors. Each entry registers an ordered_cache_behavior with grpc_config { enabled = true }. When non-empty, distribution http_version is automatically promoted to http2and3 (gRPC requires HTTP/2)."
 }
 
+variable "extra_forwarded_headers" {
+  type        = list(string)
+  default     = []
+  description = "Additional request headers to whitelist in the cache policy — included in the cache key and forwarded to origin. Appended to the module defaults (Origin, Authorization, Accept, Content-Type, User-Agent). Use for custom headers like X-A2A-Task-Secret that downstream services depend on."
+}
+
 variable "use_cors" {
   type    = bool
   default = false


### PR DESCRIPTION
Closes luthersystems/tf-modules#65. Companion to [`luthersystems/ui-infrastructure#242`](https://github.com/luthersystems/ui-infrastructure/issues/242) — production breakage where `X-A2A-Task-Secret` is dropped at the CloudFront edge, breaking every A2A resume-path call against staging.

## Root cause

`aws_cloudfront_cache_policy.respect_origin_headers` whitelists a fixed set of headers (`Origin, Authorization, Accept, Content-Type, User-Agent`). Whitelisted-mode policies forward only listed headers to origin AND include them in the cache key. `X-A2A-Task-Secret` isn't on the list, so CloudFront drops it before the origin sees it.

The downstream issue's RCA was based on the legacy `forwarded_values { ... }` syntax — the module actually uses the modern `cache_policy_id` approach, but the symptom is the same and the fix is parallel.

## Fix

New optional input on the module:

```hcl
variable "extra_forwarded_headers" {
  type        = list(string)
  default     = []
  description = "Additional request headers to whitelist in the cache policy — included in the cache key and forwarded to origin. Appended to the module defaults (Origin, Authorization, Accept, Content-Type, User-Agent). Use for custom headers like X-A2A-Task-Secret that downstream services depend on."
}
```

Wired into the cache policy via `concat`:

```hcl
items = concat(["Origin", "Authorization", "Accept", "Content-Type", "User-Agent"], var.extra_forwarded_headers)
```

## Why this approach (vs hardcoding the header)

- Generic — unblocks future custom-header needs without TF churn each time.
- Doesn't push A2A-specific knowledge into the shared module.
- Defaults to empty: existing distributions render byte-identical (no plan diff for current consumers).

## Why this approach (vs full migration to managed `CachingDisabled` + `AllViewerExceptHostHeader`)

- The downstream issue lists managed policies as "recommended (b)". Rejected here because:
  - `CachingDisabled` would force every behavior to skip cache, regressing perf for routes that legitimately benefit from caching today.
  - The custom cache policy is shared across all behaviors; per-behavior policy override is a larger refactor.
  - Adding `X-A2A-Task-Secret` to a whitelist where `cookies = "all"` and `query_strings = "all"` adds zero new cache fragmentation in practice.
- This single-line append is the minimum surface change that resolves the bug.

## Test plan

- [x] `terraform fmt -recursive aws-cf-reverse-proxy/` — clean (no diff).
- [x] `terraform validate` from `aws-cf-reverse-proxy/tests/test1/` — passes.
- [x] `extra_forwarded_headers = []` (default): cache policy `headers.items` evaluates to the original 5-element list — byte-identical plan for existing consumers.
- [ ] `extra_forwarded_headers = ["X-A2A-Task-Secret"]` (post-merge consumer): plan shows in-place update of the cache policy adding the header to `items`.

## Follow-up after merge

Maintainer to tag a new release (likely `v55.18.0` — additive, back-compat). Consumer pin bumps in `luthersystems/ui-infrastructure` and the consumer-side fix lands in the same deploy window as #240.