### PR TITLE
aws-cf-reverse-proxy: optional WAFv2 web_acl_id

### DIFF
--- a/aws-cf-reverse-proxy/README.md
+++ b/aws-cf-reverse-proxy/README.md
@@ -3,3 +3,20 @@
 Quick and dirty reverse proxy with CF.
 
 It also supports hosting on a URL that simply does 302 redirects.
+
+## Optional WAFv2
+
+Set `web_acl_id` to a CLOUDFRONT-scope WAFv2 Web ACL ARN (must be created in
+`us-east-1`) to attach edge protection (IP denylist, rate limiting, AWS managed
+rule sets, etc.). The variable defaults to `null` — when unset the distribution
+stays un-WAFed, matching the pre-existing behaviour for all callers.
+
+```hcl
+module "cf_reverse_proxy" {
+  source = "github.com/luthersystems/tf-modules.git//aws-cf-reverse-proxy?ref=v55.20.0"
+
+  # ... existing inputs ...
+
+  web_acl_id = aws_wafv2_web_acl.app_domain.arn
+}
+```

--- a/aws-cf-reverse-proxy/main.tf
+++ b/aws-cf-reverse-proxy/main.tf
@@ -138,6 +138,11 @@ resource "aws_cloudfront_distribution" "site" {
   # at least one gRPC route, so existing distributions stay byte-identical.
   http_version = length(var.grpc_routes) > 0 ? "http2and3" : "http2"
 
+  # Optional WAFv2 Web ACL attachment. Null leaves the distribution un-WAFed
+  # (the existing default for all callers), so this remains additive and
+  # backward-compatible.
+  web_acl_id = var.web_acl_id
+
   dynamic "origin" {
     for_each = local.all_origin_configs
     content {

--- a/aws-cf-reverse-proxy/vars.tf
+++ b/aws-cf-reverse-proxy/vars.tf
@@ -97,3 +97,9 @@ variable "origin_read_timeout" {
   type        = number
   default     = 60
 }
+
+variable "web_acl_id" {
+  type        = string
+  default     = null
+  description = "Optional WAFv2 Web ACL ARN to attach to the CloudFront distribution. Must be CLOUDFRONT-scope (created in us-east-1). Default null leaves the distribution un-WAFed (existing behaviour)."
+}


### PR DESCRIPTION
## Summary

Adds an optional \`web_acl_id\` input on \`aws-cf-reverse-proxy\` so callers can attach a CLOUDFRONT-scope WAFv2 Web ACL ARN to the underlying \`aws_cloudfront_distribution.site\`. Default \`null\` preserves the existing behaviour (no WAF attached) for every existing caller — fully additive, backward-compatible.

## Why

Used by [ui-infrastructure](https://github.com/luthersystems/ui-infrastructure)'s upcoming WAFv2 rollout for \`app.luthersystems.com\` (prod) and \`app-test.luthersystems.com\` (staging), which front the EKS-hosted A2A / MCP / Oracle APIs. Today these have zero edge protection — a recent spammer hammered the anonymous A2A endpoint with 700+ tasks in 20 hours. This input is the wire-up step; the actual WAFv2 Web ACL + IP set + rate-limit + AWS managed rules land in ui-infrastructure on top of this.

## Changes

- \`vars.tf\`: new \`variable "web_acl_id"\` (\`string\`, default \`null\`, must be CLOUDFRONT-scope / us-east-1).
- \`main.tf\`: pass \`web_acl_id = var.web_acl_id\` to \`aws_cloudfront_distribution.site\`. \`null\` is the documented "no WAF" value for that argument.
- \`README.md\`: short usage example.

## Validation

- \`terraform fmt -check -recursive\` clean.
- \`terraform init -backend=false && terraform validate\` in \`aws-cf-reverse-proxy/tests/test1/\` is green.
- No callers currently set the variable, so every existing consumer is byte-identical.

## Versioning / tag

Additive, backward-compatible → minor bump. Current tag is \`v55.19.0\` → intended next tag \`v55.20.0\` (to be cut by a human after merge — **I am intentionally not pushing the tag from this PR**). ui-infrastructure's companion PR pins this tag.

## Test plan

- [x] Module validates locally (\`terraform validate\`).
- [ ] CI green (\`Terraform CI\` workflow on this PR).
- [ ] After merge, human tags \`v55.20.0\` and the ui-infrastructure PR plans cleanly.