### PR TITLE
fix(aws-cf-reverse-proxy): make the duplicate-content UA marker optional

### DIFF
--- a/aws-cf-reverse-proxy/main.tf
+++ b/aws-cf-reverse-proxy/main.tf
@@ -159,9 +159,19 @@ resource "aws_cloudfront_distribution" "site" {
         origin_keepalive_timeout = 60
       }
 
-      custom_header {
-        name  = "User-Agent"
-        value = var.duplicate_content_penalty_secret
+      # Vestigial SEO trick: when set, the module injects this value as the
+      # `User-Agent` header on every CloudFront → origin request so the origin
+      # could distinguish CF-routed traffic from direct hits and respond with
+      # `X-Robots-Tag: noindex` to avoid duplicate-content SEO penalties when
+      # both CF and origin were publicly resolvable. Set to "" to disable for
+      # API/JSON origins where this overrides the real caller's User-Agent
+      # and destroys observability (origin sees the marker, never the peer).
+      dynamic "custom_header" {
+        for_each = var.duplicate_content_penalty_secret == "" ? [] : [1]
+        content {
+          name  = "User-Agent"
+          value = var.duplicate_content_penalty_secret
+        }
       }
     }
   }

--- a/aws-cf-reverse-proxy/vars.tf
+++ b/aws-cf-reverse-proxy/vars.tf
@@ -17,7 +17,17 @@ variable "app_target_domain" {
 }
 
 variable "duplicate_content_penalty_secret" {
-  type    = string
+  type = string
+  # Static-site era SEO trick: CloudFront injects this string as the
+  # `User-Agent` header on every origin request so the origin can detect
+  # CF-routed traffic and serve `X-Robots-Tag: noindex` to avoid Google
+  # duplicate-content penalties when both the CF domain and origin domain
+  # were publicly indexable.
+  #
+  # Set to "" to skip the injection. Required for API/JSON origins where
+  # the override destroys the real caller's User-Agent header and breaks
+  # downstream observability (server logs show "luthersystems" for every
+  # request regardless of who actually called).
   default = "luthersystems"
 }
 


### PR DESCRIPTION
## Summary

`aws-cf-reverse-proxy` unconditionally injects `User-Agent: <duplicate_content_penalty_secret>` (default `"luthersystems"`) on every CloudFront → origin request. This is a static-site-era SEO trick: when the same content was reachable through both the CF domain and the origin domain, origin servers detected the marker UA and responded with `X-Robots-Tag: noindex` so Google wouldn't penalise the duplicate.

For API / JSON origins (our A2A, MCP, gRPC paths) the trick is irrelevant **and actively harmful** — every inbound peer's real UA is destroyed at CloudFront before reaching origin, breaking observability and spam attribution.

Discovered while investigating GCP IPs hitting `/insideout-a2a/*` on prod. Every A2A session in the admin UI showed `User-Agent: luthersystems` because that's literally what CF was forwarding, regardless of the actual peer's UA. Pairs with [luthersystems/reliable#1805](https://github.com/luthersystems/reliable/pull/1805) which adds the deeper probe attribution we needed once we realised UA was a dead end.

## What changes

Wrap the `custom_header` in a `dynamic` block keyed on `var.duplicate_content_penalty_secret != ""`:

- **Default (preserved)**: still injects `User-Agent: luthersystems` — every existing caller of this module gets identical behaviour.
- **Opt-out**: callers pass `duplicate_content_penalty_secret = ""` to disable the injection for API origins (or anywhere the trick is unwanted).

Docstring on the variable now explains both the SEO origin and when to disable.

## Test plan

- [x] `terraform fmt -check -recursive aws-cf-reverse-proxy/` clean
- [ ] Reviewer: spot-check that the default-on path produces an identical TF plan against an existing prod / test app domain (no diff)
- [ ] After merge + version tag: bump `aws-cf-reverse-proxy?ref=` in `ui-infrastructure/platform-{prod,test}/app_domain.tf` to the new tag AND set `duplicate_content_penalty_secret = ""` on the app domain module — that's the operational fix that restores real UA on `app.luthersystems.com`-fronted A2A/MCP/gRPC traffic.

## Out of scope

- `ui-infrastructure` bump (separate PR after this lands and we cut a tag)
- The other ~10 callers of this module in our repo (`metrics-lambda` etc.) keep the default and aren't affected