### PR TITLE
fix(eks-vpc): upgrade Amazon Managed Grafana workspace to 10.4

### DIFF
--- a/eks-vpc/monitoring.tf
+++ b/eks-vpc/monitoring.tf
@@ -282,7 +282,7 @@ resource "aws_grafana_workspace" "grafana" {
   permission_type          = "SERVICE_MANAGED"
   role_arn                 = aws_iam_role.grafana.arn
   data_sources             = ["PROMETHEUS"]
-  grafana_version          = "9.4"
+  grafana_version          = "10.4"
   tags                     = module.luthername_grafana.tags
 }
 


### PR DESCRIPTION
AWS disabled the Snowflake plugin on all AMG workspaces running Grafana 8/9 and will only ship the fix for 10+ (AWS Health `AWS_GRAFANA_SECURITY_NOTIFICATION`, 2026-06-09, account 343039485463/us-west-2). The workspace must be upgraded to clear the notice; AMG offers `10.4` as the only target (`aws grafana list-versions`).

One-line bump of `grafana_version` in `eks-vpc/monitoring.tf`. The AWS provider performs this as an in-place workspace upgrade (supported since hashicorp/aws 5.31; consumers are on 5.100.0).

Rollout: tag a release, then bump `?ref=` for `aws-platform-ui-main` in ui-infrastructure (test first, then prod — the workspace only exists in prod, `monitoring = true`).