### PR TITLE
feat(aws-platform-ui-bootstrap): optional deploy_policy_json + permissions_boundary_arn inputs (non-breaking)

### DIFF
--- a/aws-platform-ui-bootstrap/admin.tf
+++ b/aws-platform-ui-bootstrap/admin.tf
@@ -12,16 +12,43 @@ resource "aws_iam_role" "admin" {
   name               = var.admin_role_name
   description        = "Provides administrator level access"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  tags               = module.luthername_admin_role.tags
+
+  # Optional deny-only cap (sandbox-infrastructure-template#147). Defaults to
+  # null — identical to today's behavior — unless the caller passes
+  # permissions_boundary_arn.
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : null
+
+  tags = module.luthername_admin_role.tags
 
   lifecycle {
     ignore_changes = [managed_policy_arns]
   }
 }
 
+# Customer-managed deploy policy — created only when the caller supplies a
+# policy body (sandbox-infrastructure-template#147: replacing the
+# AdministratorAccess attachment on the durable terraform role with a scoped
+# InsideOutWrite policy).
+resource "aws_iam_policy" "deploy" {
+  count = var.deploy_policy_json != "" ? 1 : 0
+
+  name        = "${var.admin_role_name}-deploy"
+  description = "Customer-managed deploy policy for ${var.admin_role_name}, attached in place of AdministratorAccess"
+  policy      = var.deploy_policy_json
+
+  tags = module.luthername_admin_role.tags
+}
+
+# NOTE: deliberately NOT count-gated. Keeping this resource unconditional and
+# swapping only its policy_arn preserves the resource address
+# `aws_iam_role_policy_attachment.admin` for every existing consumer. Gating it
+# with count would re-address it to `...admin[0]`, planning a destroy+create of
+# the SAME (role, AdministratorAccess) pair whose apply order is not
+# guaranteed — the detach can land after the re-attach and leave the role with
+# no policy at all.
 resource "aws_iam_role_policy_attachment" "admin" {
   role       = aws_iam_role.admin.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  policy_arn = var.deploy_policy_json != "" ? aws_iam_policy.deploy[0].arn : "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/aws-platform-ui-bootstrap/vars.tf
+++ b/aws-platform-ui-bootstrap/vars.tf
@@ -37,3 +37,21 @@ variable "kms_alias_suffix" {
   type    = string
   default = "tfstate"
 }
+
+# Optional least-privilege inputs for the admin (deploy) role — see
+# luthersystems/sandbox-infrastructure-template#147 and its design doc
+# (docs/design/least-privilege-deploy-role.md). Both default to "" so every
+# existing consumer keeps EXACTLY the current behavior (AdministratorAccess
+# attached, no permissions boundary) until it opts in.
+
+variable "deploy_policy_json" {
+  description = "Optional JSON policy body for a customer-managed deploy policy. When non-empty, the module creates the policy and attaches it to the admin role IN PLACE OF the AWS-managed AdministratorAccess policy. When empty (default), AdministratorAccess is attached, unchanged."
+  type        = string
+  default     = ""
+}
+
+variable "permissions_boundary_arn" {
+  description = "Optional IAM permissions-boundary policy ARN to set on the admin role (defense-in-depth cap). When empty (default), no boundary is set, unchanged."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

tf-modules half of Phase 0 of the least-privilege deploy-role migration (luthersystems/sandbox-infrastructure-template#147, design doc `docs/design/least-privilege-deploy-role.md` §8.1 in that repo). Gives callers of `aws-platform-ui-bootstrap` the inputs needed to swap the durable `-luther-terraform` role's `AdministratorAccess` attachment for a customer-managed deploy policy, and to cap the role with a permissions boundary.

## Changes

- `deploy_policy_json` (string, default `""`): when non-empty, the module creates `aws_iam_policy.deploy` from the supplied body and attaches it to the admin role **instead of** `arn:aws:iam::aws:policy/AdministratorAccess`. When empty: exactly current behavior.
- `permissions_boundary_arn` (string, default `""`): when non-empty, sets `permissions_boundary` on the role; when empty: unset (`null`), current behavior.
- Implementation note: `aws_iam_role_policy_attachment.admin` stays **unconditional** with a ternary `policy_arn`, rather than count-gated. A `count` would re-address the resource to `admin[0]` and plan an order-unguaranteed destroy+create of the same (role, AdministratorAccess) pair — the detach can land after the re-attach and leave the role with no policy. The ternary keeps the state address stable for every existing consumer; only `aws_iam_policy.deploy` is count-gated.

## Non-breaking contract

- Both new variables are optional with `""` defaults — **a no-op for every existing consumer**. Verified consumers: `sandbox-infrastructure-template/tf/cloud-provision` (pins `?ref=v55.15.2`) and `ui-infrastructure/env-bootstrap` (pins `?ref=v55.16.0`); neither passes the new inputs, and pinned refs don't move until bumped.
- With defaults, the rendered config is attribute-identical to today (`permissions_boundary = null` ≡ unset; same attachment address and ARN) — a consumer bumping the tag without wiring the inputs plans zero changes for this module.

## Consumer sequencing

1. Merge this PR → cut a new `vX.Y.Z` tag.
2. `sandbox-infrastructure-template` bumps the `?ref=` in `tf/cloud-provision/aws-resources.tf.tmpl` and wires `deploy_policy_json` (Phase-0 admin-equivalent body) + `permissions_boundary_arn` through cloud-provision. **That wiring PR is a deliberate follow-up after the tag exists — not part of this train.**

## Verification

- `terraform fmt -check` clean
- `terraform init -backend=false` + `terraform validate` clean on the module (only pre-existing `managed_policy_arns` deprecation warnings, untouched by this change)
- Matches the repo CI (`main.yml` per-module init/validate matrix); module has no `tftest` suite

Refs luthersystems/sandbox-infrastructure-template#147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_